### PR TITLE
WIP: CI Workflow Refactor

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,80 +1,374 @@
 name: pull request
-on: 
+on:
   pull_request:
     branches:
       - master
       - main
+
+env:
+  DEFAULT_BUNDLE_VERSION: "0.0.1"
+  DEFAULT_BUNDLE_CHANNEL: "alpha"
+  DEFAULT_OPERATOR_VERSION: "latest"
+  OPERATOR_SDK_VERSION: "v1.9.0"
+  BUILD_PLATFORMS: "linux/amd64,linux/arm64,linux/ppc64le"
+
 jobs:
-  build:
+  setup:
     runs-on: ubuntu-latest
-    name: build
+    name: setup
     steps:
+      - name: Setting Workflow Variables
+        id: set-variables
+        run: |
+          echo "::set-output name=repository_name::$(basename $GITHUB_REPOSITORY)"
+          echo "::set-output name=bin_dir::${HOME}/bin"
 
-    - name: set repo name
-      shell: bash
-      run: | 
-        echo "REPOSITORY_NAME=$(basename $GITHUB_REPOSITORY)" >> $GITHUB_ENV    
+          # Create Distribution Matrix
+          echo "::set-output name=dist_matrix::$(echo -n "${{ env.BUILD_PLATFORMS }}" | jq -csR '. | split(",")')"
 
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v2
-      with:
-        go-version: ^1.16
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      - name: Setting Image Variables
+        id: set-variables-image
+        run: |
+          if [ "${{ secrets.OPERATOR_IMAGE_REPOSITORY }}" == "" ]; then
+            echo "::set-output name=operator_image_repository_name::${{ steps.set-variables.outputs.repository_name }}"
+            echo "::set-output name=operator_image_registry::quay.io/${{ github.repository_owner }}"
+          else
+            OPERATOR_IMAGE_REPOSITORY="${{ secrets.OPERATOR_IMAGE_REPOSITORY }}"
+            echo "::set-output name=operator_image_repository_name::${OPERATOR_IMAGE_REPOSITORY##*/}"
+            echo "::set-output name=operator_image_registry::${OPERATOR_IMAGE_REPOSITORY%/*}"
+          fi
 
-    # - uses: shivanshs9/setup-k8s-operator-sdk@v1
-    #   with:
-    #     version: "1.9.0" # The operator-sdk version to download (if necessary) and use.      
+          if [ "${{ secrets.BUNDLE_IMAGE_REPOSITORY }}" == "" ]; then
+            echo "::set-output name=bundle_image_repository_name::${{ steps.set-variables.outputs.repository_name }}-bundle"
+            echo "::set-output name=bundle_image_registry::quay.io/${{ github.repository_owner }}"
 
-    - name: Download operator sdk
-      shell: bash
-      env:
-        RELEASE_VERSION: v1.9.0
-      run: | 
-        curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk_linux_amd64
-        chmod +x operator-sdk_linux_amd64
-        mkdir ${HOME}/bin
-        mv operator-sdk_linux_amd64 ${HOME}/bin/operator-sdk
-        echo "${HOME}/bin" >> $GITHUB_PATH 
+          else
+            BUNDLE_IMAGE_REPOSITORY="${{ secrets.BUNDLE_IMAGE_REPOSITORY }}"
+            echo "::set-output name=bundle_image_repository_name::${BUNDLE_IMAGE_REPOSITORY##*/}"
+            echo "::set-output name=bundle_image_registry::${BUNDLE_IMAGE_REPOSITORY%/*}"
+          fi
 
-    - name: build code
-      shell: bash
-      run:  make VERSION=latest
-      
-    - name: build bundle
-      shell: bash
-      run: make bundle IMG=quay.io/${{ github.repository_owner }}/$(basename $GITHUB_REPOSITORY):0.0.1 VERSION=0.0.1 DEFAULT_CHANNEL=alpha
+          # Set versions based on presence of tag
+          if [[ "${{ github.ref }}" =~ ^refs/tags/ ]]; then
+            TAG="${GITHUB_REF/refs\/tags\//}"
+            echo "::set-output name=tag_event::true"
+            echo "::set-output name=operator_version::$TAG"
+            echo "::set-output name=bundle_version::${TAG:1}"
+          else
+            echo "::set-output name=tag_event::false"
+            echo "::set-output name=operator_version::$DEFAULT_OPERATOR_VERSION"
+            echo "::set-output name=bundle_version::$DEFAULT_BUNDLE_VERSION"
+          fi
 
-    - name: verify bundle
-      shell: bash
-      run: operator-sdk bundle validate ./bundle --select-optional name=operatorhub
+      - name: Build Go Cache Paths
+        id: go-cache-paths
+        run: |
+          echo "::set-output name=go-build::$(go env GOCACHE)"
+          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
 
-    - name: build chart
-      shell: bash
-      run: make helmchart VERSION=0.0.1 IMG=quay.io/${{ github.repository_owner }}/$(basename $GITHUB_REPOSITORY):0.0.1
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v1
+        with:
+          go-version: ^1.16
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-      with:
-        platforms: all      
-    
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1  
+      - name: Check out code
+        uses: actions/checkout@v2
 
-    - name: "Build Operator Image"
-      uses: docker/build-push-action@v2
-      with:
-        context: .
-        file: ./Dockerfile
-        platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
-        push: false
-        tags: "quay.io/${{ github.repository_owner }}/${{ env.REPOSITORY_NAME }}:v0.0.1"
+      - name: Go Build Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-build }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
 
-    - name: "Build Bundle Image"
-      uses: docker/build-push-action@v2
-      with:
-        context: .
-        file: ./bundle.Dockerfile
-        platforms: linux/amd64,linux/arm64,linux/ppc64le
-        push: false
-        tags: "quay.io/${{ github.repository_owner }}/${{ env.REPOSITORY_NAME }}-bundle:0.0.1"       
+      - name: Go Mod Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+
+      - name: Go Dependencies
+        run: go mod download
+
+      - name: Download Binaries
+        run: |
+          # Create Binary Directory
+          mkdir -p ${{ steps.set-variables.outputs.bin_dir }}
+
+          # Operator SDK
+          curl -L -o ${{ steps.set-variables.outputs.bin_dir }}/operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk_linux_amd64
+
+          # Controller-gen
+          make controller-gen
+
+          # Kustomize
+          make kustomize
+
+      - name: Upload Support Binaries
+        uses: actions/upload-artifact@v2
+        with:
+          name: support-binaries
+          path: ${{ steps.set-variables.outputs.bin_dir }}
+    outputs:
+      repository_name: ${{ steps.set-variables.outputs.repository_name }}
+      bin_dir: ${{ steps.set-variables.outputs.bin_dir }}
+      operator_image_repository_name: ${{ steps.set-variables-image.outputs.operator_image_repository_name}}
+      operator_image_registry: ${{ steps.set-variables-image.outputs.operator_image_registry }}
+      bundle_image_repository_name: ${{ steps.set-variables-image.outputs.bundle_image_repository_name }}
+      bundle_image_registry: ${{ steps.set-variables-image.outputs.bundle_image_registry }}
+      go_build: ${{ steps.go-cache-paths.outputs.go-build }}
+      go_mod: ${{ steps.go-cache-paths.outputs.go-mod }}
+      operator_version: ${{ steps.set-variables-image.outputs.operator_version }}
+      bundle_version: ${{ steps.set-variables-image.outputs.bundle_version }}
+      tag_event: ${{ steps.set-variables-image.outputs.tag_event }}
+      dist_matrix: ${{ steps.set-variables.outputs.dist_matrix }}
+
+  build-operator:
+    runs-on: ubuntu-latest
+    name: build-operator
+    needs: ["setup"]
+    strategy:
+      matrix:
+        platform: ${{ fromJson(needs.setup.outputs.dist_matrix) }}
+    env:
+      REPOSITORY_NAME: ${{ needs.setup.outputs.repository_name }}
+      OPERATOR_VERSION: ${{ needs.setup.outputs.operator_version }}
+      BUNDLE_VERSION: ${{ needs.setup.outputs.bundle_version }}
+      OPERATOR_IMAGE_REPOSITORY: "${{ needs.setup.outputs.operator_image_registry }}/${{ needs.setup.outputs.operator_image_repository_name }}"
+      OPERATOR_IMAGE_REGISTRY: ${{ needs.setup.outputs.operator_image_registry }}
+      BUNDLE_IMAGE_REPOSITORY: "${{ needs.setup.outputs.bundle_image_registry }}/${{ needs.setup.outputs.bundle_image_repository_name }}"
+      BUNDLE_IMAGE_REGISTRY: ${{ needs.setup.outputs.bundle_image_registry }}
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v1
+        with:
+          go-version: ^1.16
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Go Build Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ needs.setup.outputs.go_build }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+
+      - name: Go Mod Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ needs.setup.outputs.go_mod }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+
+      - name: Download Support Binaries
+        uses: actions/download-artifact@v2
+        with:
+          name: support-binaries
+          path: ${{ needs.setup.outputs.bin_dir }}
+
+      - name: Prepare Build Step
+        id: setup-build-step
+        run: |
+          # Setup Path
+          echo "${{ needs.setup.outputs.bin_dir }}" >> $GITHUB_PATH
+
+          # Make Binaries Executable
+          chmod +x ${{ needs.setup.outputs.bin_dir }}/*
+
+          # Configure Platform Variables
+          echo "::set-output name=platform_os::$(echo ${{ matrix.platform }} |  cut -d/ -f1)"
+          echo "::set-output name=platform_arch::$(echo ${{ matrix.platform }} |  cut -d/ -f2)"
+
+      - name: Download Dependencies
+        shell: bash
+        run: |
+          make generate
+          make fmt
+          make vet
+
+      - name: build code
+        shell: bash
+        env:
+          VERSION: latest
+          GOOS: ${{ steps.setup-build-step.outputs.platform_os }}
+          GOARCH: ${{ steps.setup-build-step.outputs.platform_arch }}
+        run: make
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: "Build Operator Image"
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./ci.Dockerfile
+          platforms: ${{ matrix.platform }}
+          push: false
+          tags: "${{ env.OPERATOR_IMAGE_REPOSITORY }}:latest,${{ env.OPERATOR_IMAGE_REPOSITORY }}:${{ env.OPERATOR_VERSION }}"
+
+      - name: Prepare Distribution Artifacts
+        shell: bash
+        run: |
+          # Create Distribution Directory
+          mkdir dist
+
+          # Move and Rename Manager Binary
+          mv bin/manager dist/${{ env.REPOSITORY_NAME }}-manager-${{ env.OPERATOR_VERSION }}-${{ steps.setup-build-step.outputs.platform_os }}-${{ steps.setup-build-step.outputs.platform_arch }}
+
+      - name: Upload Dist
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: dist
+
+  build-bundle:
+    runs-on: ubuntu-latest
+    name: build-bundle
+    needs: ["setup"]
+    env:
+      REPOSITORY_NAME: ${{ needs.setup.outputs.repository_name }}
+      OPERATOR_VERSION: ${{ needs.setup.outputs.operator_version }}
+      BUNDLE_VERSION: ${{ needs.setup.outputs.bundle_version }}
+      OPERATOR_IMAGE_REPOSITORY: "${{ needs.setup.outputs.operator_image_registry }}/${{ needs.setup.outputs.operator_image_repository_name }}"
+      OPERATOR_IMAGE_REGISTRY: ${{ needs.setup.outputs.operator_image_registry }}
+      BUNDLE_IMAGE_REPOSITORY: "${{ needs.setup.outputs.bundle_image_registry }}/${{ needs.setup.outputs.bundle_image_repository_name }}"
+      BUNDLE_IMAGE_REGISTRY: ${{ needs.setup.outputs.bundle_image_registry }}
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v1
+        with:
+          go-version: ^1.16
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Go Build Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ needs.setup.outputs.go_build }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+
+      - name: Go Mod Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ needs.setup.outputs.go_mod }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+
+      - name: Download Binaries
+        uses: actions/download-artifact@v2
+        with:
+          name: support-binaries
+          path: ${{ needs.setup.outputs.bin_dir }}
+
+      - name: Prepare Build Step
+        id: setup-build-step
+        run: |
+          # Setup Path
+          echo "${{ needs.setup.outputs.bin_dir }}" >> $GITHUB_PATH
+
+          # Make Binaries Executable
+          chmod +x ${{ needs.setup.outputs.bin_dir }}/*
+
+      - name: build bundle
+        shell: bash
+        run: make bundle IMG=${{ env.OPERATOR_IMAGE_REPOSITORY }}:${{ env.OPERATOR_VERSION }} VERSION=${{ env.BUNDLE_VERSION }} DEFAULT_CHANNEL=${{ env.DEFAULT_BUNDLE_CHANNEL }}
+
+      - name: verify bundle
+        shell: bash
+        run: operator-sdk bundle validate ./bundle --select-optional name=operatorhub
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: "Build Bundle Image"
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+
+          file: ./bundle.Dockerfile
+          platforms: ${{ matrix.platform }}
+          push: false
+          tags: "${{ env.BUNDLE_IMAGE_REPOSITORY }}:latest,${{ env.BUNDLE_IMAGE_REPOSITORY }}:${{ env.BUNDLE_VERSION }}"
+
+      - name: Prepare Distribution Artifacts
+        shell: bash
+        run: |
+          # Create Distribution Directory
+          mkdir dist
+
+          # Prepare Bundle
+          cp -R bundle ${{ env.REPOSITORY_NAME }}-bundle-${{ env.OPERATOR_VERSION }}
+          tar -czvf ${{ env.REPOSITORY_NAME }}-bundle-${{ env.OPERATOR_VERSION }}.tar.gz ${{ env.REPOSITORY_NAME }}-bundle-${{ env.OPERATOR_VERSION }}
+          mv ${{ env.REPOSITORY_NAME }}-bundle-${{ env.OPERATOR_VERSION }}.tar.gz dist
+          rm -Rf ${{ env.REPOSITORY_NAME }}-bundle-${{ env.OPERATOR_VERSION }}
+
+      - name: Upload Dist
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: dist
+
+  package-helm:
+    runs-on: ubuntu-latest
+    name: package-helm
+    needs: ["setup"]
+    env:
+      REPOSITORY_NAME: ${{ needs.setup.outputs.repository_name }}
+      OPERATOR_VERSION: ${{ needs.setup.outputs.operator_version }}
+      HELM_RELEASE_VERSION: ${{ needs.setup.outputs.bundle_version }}
+      OPERATOR_IMAGE_REPOSITORY: "${{ needs.setup.outputs.operator_image_registry }}/${{ needs.setup.outputs.operator_image_repository_name }}"
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v1
+        with:
+          go-version: ^1.16
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Go Build Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ needs.setup.outputs.go_build }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+
+      - name: Go Mod Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ needs.setup.outputs.go_mod }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+
+      - name: Download Binaries
+        uses: actions/download-artifact@v2
+        with:
+          name: support-binaries
+          path: ${{ needs.setup.outputs.bin_dir }}
+
+      - name: Prepare Build Step
+        id: setup-build-step
+        run: |
+          # Setup Path
+          echo "${{ needs.setup.outputs.bin_dir }}" >> $GITHUB_PATH
+
+          # Make Binaries Executable
+          chmod +x ${{ needs.setup.outputs.bin_dir }}/*
+
+      - name: Build and Package Helm Chart
+        shell: bash
+        run: |
+          # Render Helm Chart
+          make helmchart VERSION=${{ env.HELM_RELEASE_VERSION }} IMG=${{ env.OPERATOR_IMAGE_REPOSITORY }}:${{ env.OPERATOR_VERSION }}
+
+          # Package Helm Chart
+          mkdir dist
+          helm package -d dist ./charts/${{ env.REPOSITORY_NAME }}
+
+      - name: Upload Dist
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: dist

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,186 +1,448 @@
 name: push
-on: 
+on:
   push:
     branches:
       - master
       - main
-    tags:        
+    tags:
       - v*
-    
+
+env:
+  DEFAULT_BUNDLE_VERSION: "0.0.1"
+  DEFAULT_BUNDLE_CHANNEL: "alpha"
+  DEFAULT_OPERATOR_VERSION: "latest"
+  OPERATOR_SDK_VERSION: "v1.9.0"
+  BUILD_PLATFORMS: "linux/amd64,linux/arm64,linux/ppc64le"
+  HELM_REPO_DIR: "./tmp/gh-pages"
+
 jobs:
-  build:
+  setup:
     runs-on: ubuntu-latest
-    name: build
+    name: setup
     steps:
+      - name: Check if registry secrets are set
+        run: |
+          if [ "${{ secrets.REGISTRY_USERNAME }}" == "" ] || [ "${{ secrets.REGISTRY_PASSWORD }}" == "" ]; then
+            echo "Required Secrets 'REGISTRY_USERNAME' or 'REGISTRY_PASSWORD' are not set!"
+            exit 1
+          fi
 
-    - name: set repo name
-      shell: bash
-      run: | 
-        echo "REPOSITORY_NAME=$(basename $GITHUB_REPOSITORY)" >> $GITHUB_ENV    
+      - name: Check if community operators PAT secret is set
+        run: |
+          if [ "${{ secrets.COMMUNITY_OPERATOR_PAT }}" == "" ]; then
+            echo "Required Secret 'COMMUNITY_OPERATOR_PAT' is not set"
+            exit 1
+          fi
 
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v2
-      with:
-        go-version: ^1.16
+      - name: Setting Workflow Variables
+        id: set-variables
+        run: |
+          echo "::set-output name=repository_name::$(basename $GITHUB_REPOSITORY)"
+          echo "::set-output name=bin_dir::$(pwd)/bin"
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+          # Create Distribution Matrix
+          echo "::set-output name=dist_matrix::$(echo -n "${{ env.BUILD_PLATFORMS }}" | jq -csR '. | split(",")')"
 
-    # - uses: shivanshs9/setup-k8s-operator-sdk@v1
-    #   with:
-    #     version: "1.9.0" # The operator-sdk version to download (if necessary) and use.      
+      - name: Setting Image Variables
+        id: set-variables-image
+        run: |
+          if [ "${{ secrets.OPERATOR_IMAGE_REPOSITORY }}" == "" ]; then
+            echo "::set-output name=operator_image_repository_name::${{ steps.set-variables.outputs.repository_name }}"
+            echo "::set-output name=operator_image_registry::quay.io/${{ github.repository_owner }}"
+          else
+            OPERATOR_IMAGE_REPOSITORY="${{ secrets.OPERATOR_IMAGE_REPOSITORY }}"
+            echo "::set-output name=operator_image_repository_name::${OPERATOR_IMAGE_REPOSITORY##*/}"
+            echo "::set-output name=operator_image_registry::${OPERATOR_IMAGE_REPOSITORY%/*}"
+          fi
 
-    - name: Download operator sdk
-      shell: bash
-      env:
-        RELEASE_VERSION: v1.9.0
-      run: | 
-        curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk_linux_amd64
-        chmod +x operator-sdk_linux_amd64
-        mkdir ${HOME}/bin
-        mv operator-sdk_linux_amd64 ${HOME}/bin/operator-sdk
-        echo "${HOME}/bin" >> $GITHUB_PATH
+          if [ "${{ secrets.BUNDLE_IMAGE_REPOSITORY }}" == "" ]; then
+            echo "::set-output name=bundle_image_repository_name::${{ steps.set-variables.outputs.repository_name }}-bundle"
+            echo "::set-output name=bundle_image_registry::quay.io/${{ github.repository_owner }}"
 
-    - name: Get the version for tags
-      id: get_version1
-      if: "startsWith(github.ref, 'refs/tags')"
-      shell: bash
-      run: |
-        echo "OPERATOR_IMAGE_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
-        echo "BUNDLE_IMAGE_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
-        export TAG=${GITHUB_REF/refs\/tags\//}
-        echo "BUNDLE_VERSION=${TAG:1}" >> $GITHUB_ENV
-        export SEMVER_COMPLIANT=$(echo ${TAG:1} | egrep '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-((?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$')
-        if [ -z "$SEMVER_COMPLIANT" ]; then   echo "invalid semver tag ${GITHUB_REF/refs\/tags\//}"; exit 1; fi
+          else
+            BUNDLE_IMAGE_REPOSITORY="${{ secrets.BUNDLE_IMAGE_REPOSITORY }}"
+            echo "::set-output name=bundle_image_repository_name::${BUNDLE_IMAGE_REPOSITORY##*/}"
+            echo "::set-output name=bundle_image_registry::${BUNDLE_IMAGE_REPOSITORY%/*}"
+          fi
 
-    - name: Get the version for merge
-      id: get_version2
-      if: "! startsWith(github.ref, 'refs/tags')"
-      shell: bash 
-      run: |
-        echo "OPERATOR_IMAGE_TAG=latest" >> $GITHUB_ENV
-        echo "BUNDLE_IMAGE_TAG=v0.0.1" >> $GITHUB_ENV
-        echo "BUNDLE_VERSION=0.0.1" >> $GITHUB_ENV 
+          # Set versions based on presence of tag
+          if [[ "${{ github.ref }}" =~ ^refs/tags/ ]]; then
+            TAG="${GITHUB_REF/refs\/tags\//}"
+            echo "::set-output name=tag_event::true"
+            echo "::set-output name=operator_version::$TAG"
+            echo "::set-output name=bundle_version::${TAG:1}"
+          else
+            echo "::set-output name=tag_event::false"
+            echo "::set-output name=operator_version::$DEFAULT_OPERATOR_VERSION"
+            echo "::set-output name=bundle_version::$DEFAULT_BUNDLE_VERSION"
+          fi
 
-    - name: build code
-      run:  make
-      shell: bash
-      
-    - name: build bundle
-      shell: bash 
-      run: |
-        make bundle IMG=quay.io/${{ github.repository_owner }}/$(basename $GITHUB_REPOSITORY):${OPERATOR_IMAGE_TAG} VERSION=${BUNDLE_VERSION} DEFAULT_CHANNEL=alpha
+      - name: Verify Semver Release
+        if: ${{ steps.set-variables-image.outputs.tag_event == 'true' }}
+        uses: rubenesp87/semver-validation-action@0.0.6
+        with:
+          version: "${{ steps.set-variables-image.outputs.bundle_version }}"
 
-    - name: verify bundle
-      shell: bash
-      run: operator-sdk bundle validate ./bundle --select-optional name=operatorhub
+      - name: Build Go Cache Paths
+        id: go-cache-paths
+        run: |
+          echo "::set-output name=go-build::$(go env GOCACHE)"
+          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
 
-    - name: build chart
-      shell: bash
-      run: make helmchart VERSION=${BUNDLE_VERSION} IMG=quay.io/${{ github.repository_owner }}/$(basename $GITHUB_REPOSITORY):${OPERATOR_IMAGE_TAG}      
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v1
+        with:
+          go-version: ^1.16
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-      with:
-        platforms: all      
-    
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-      
-    - name: Login to DockerHub
-      uses: docker/login-action@v1 
-      with:
-        registry: quay.io/${{ github.repository_owner }}
-        username: ${{ secrets.QUAY_USERNAME }}
-        password: ${{ secrets.QUAY_PASSWORD }}      
+      - name: Check out code
+        uses: actions/checkout@v2
 
-    - name: "Build and Push Operator Image"
-      uses: docker/build-push-action@v2
-      with:
-        context: .
-        file: ./Dockerfile
-        platforms: linux/amd64,linux/arm64,linux/ppc64le
-        push: true
-        tags: "quay.io/${{ github.repository_owner }}/${{ env.REPOSITORY_NAME }}:${{ env.OPERATOR_IMAGE_TAG }}"
+      - name: Go Build Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-build }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
 
-    - name: "Build and Push Bundle Image"
-      uses: docker/build-push-action@v2
-      with:
-        context: .
-        file: ./bundle.Dockerfile
-        platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
-        push: true
-        tags: "quay.io/${{ github.repository_owner }}/${{ env.REPOSITORY_NAME }}-bundle:${{ env.BUNDLE_IMAGE_TAG }}" 
+      - name: Go Mod Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
 
-    - name: "Verify bundle image"
-      shell: bash
-      run: operator-sdk bundle validate quay.io/${{ github.repository_owner }}/$(basename $GITHUB_REPOSITORY)-bundle:${BUNDLE_IMAGE_TAG} --select-optional name=operatorhub    
+      - name: Go Dependencies
+        run: go mod download
 
-    - name: process bundle for disconnected support
-      uses: redhat-cop/github-actions/disconnected-csv@master
-      with:
-        CSV_FILE: bundle/manifests/${{ env.REPOSITORY_NAME }}.clusterserviceversion.yaml
-        TAGS_TO_DIGESTS: ${OPERATOR_IMAGE_TAG}
+      - name: Download Binaries
+        run: |
+          # Create Binary Directory
+          mkdir -p ${{ steps.set-variables.outputs.bin_dir }}
 
-  release-helm-chart:
-    name: Helm Chart Release      
+          # Operator SDK
+          curl -L -o ${{ steps.set-variables.outputs.bin_dir }}/operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk_linux_amd64
+
+          # Controller-gen
+          make controller-gen
+
+          # Kustomize
+          make kustomize
+
+      - name: Upload Support Binaries
+        uses: actions/upload-artifact@v2
+        with:
+          name: support-binaries
+          path: ${{ steps.set-variables.outputs.bin_dir }}
+    outputs:
+      repository_name: ${{ steps.set-variables.outputs.repository_name }}
+      bin_dir: ${{ steps.set-variables.outputs.bin_dir }}
+      operator_image_repository_name: ${{ steps.set-variables-image.outputs.operator_image_repository_name}}
+      operator_image_registry: ${{ steps.set-variables-image.outputs.operator_image_registry }}
+      bundle_image_repository_name: ${{ steps.set-variables-image.outputs.bundle_image_repository_name }}
+      bundle_image_registry: ${{ steps.set-variables-image.outputs.bundle_image_registry }}
+      go_build: ${{ steps.go-cache-paths.outputs.go-build }}
+      go_mod: ${{ steps.go-cache-paths.outputs.go-mod }}
+      operator_version: ${{ steps.set-variables-image.outputs.operator_version }}
+      bundle_version: ${{ steps.set-variables-image.outputs.bundle_version }}
+      tag_event: ${{ steps.set-variables-image.outputs.tag_event }}
+      dist_matrix: ${{ steps.set-variables.outputs.dist_matrix }}
+
+  build-operator:
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags')"
-    needs: ["build"]
+    name: build-operator
+    needs: ["setup"]
+    strategy:
+      matrix:
+        platform: ${{ fromJson(needs.setup.outputs.dist_matrix) }}
+    env:
+      REPOSITORY_NAME: ${{ needs.setup.outputs.repository_name }}
+      OPERATOR_VERSION: ${{ needs.setup.outputs.operator_version }}
+      BUNDLE_VERSION: ${{ needs.setup.outputs.bundle_version }}
+      OPERATOR_IMAGE_REPOSITORY: "${{ needs.setup.outputs.operator_image_registry }}/${{ needs.setup.outputs.operator_image_repository_name }}"
+      OPERATOR_IMAGE_REGISTRY: ${{ needs.setup.outputs.operator_image_registry }}
+      BUNDLE_IMAGE_REPOSITORY: "${{ needs.setup.outputs.bundle_image_registry }}/${{ needs.setup.outputs.bundle_image_repository_name }}"
+      BUNDLE_IMAGE_REGISTRY: ${{ needs.setup.outputs.bundle_image_registry }}
     steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v1
+        with:
+          go-version: ^1.16
 
-      - name: set repo name
-        shell: bash
-        run: | 
-          echo "REPOSITORY_NAME=$(basename $GITHUB_REPOSITORY)" >> $GITHUB_ENV
+      - name: Check out code
+        uses: actions/checkout@v2
 
-      - name: Checkout
-        uses: actions/checkout@v2       
-      
-      - name: Get the version
-        id: get_version
-        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+      - name: Go Build Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ needs.setup.outputs.go_build }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
 
-      - name: Configure Git
+      - name: Go Mod Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ needs.setup.outputs.go_mod }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+
+      - name: Download Support Binaries
+        uses: actions/download-artifact@v2
+        with:
+          name: support-binaries
+          path: ${{ needs.setup.outputs.bin_dir }}
+
+      - name: Prepare Build Step
+        id: setup-build-step
+        run: |
+          # Setup Path
+          echo "${{ needs.setup.outputs.bin_dir }}" >> $GITHUB_PATH
+
+          # Make Binaries Executable
+          chmod +x ${{ needs.setup.outputs.bin_dir }}/*
+
+          # Configure Platform Variables
+          echo "::set-output name=platform_os::$(echo ${{ matrix.platform }} |  cut -d/ -f1)"
+          echo "::set-output name=platform_arch::$(echo ${{ matrix.platform }} |  cut -d/ -f2)"
+
+      - name: Download Dependencies
         shell: bash
         run: |
-          git config --global user.name "$GITHUB_ACTOR"
-          git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          make generate
+          make fmt
+          make vet
 
-      - name: checkout gh-pages
-        uses: actions/checkout@v2
+      - name: build code
+        shell: bash
+        env:
+          VERSION: latest
+          GOOS: ${{ steps.setup-build-step.outputs.platform_os }}
+          GOARCH: ${{ steps.setup-build-step.outputs.platform_arch }}
+        run: make
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Operator Registry
+        uses: docker/login-action@v1
         with:
-          path: ./tmp/gh-pages
-          ref: gh-pages
+          registry: ${{ env.OPERATOR_IMAGE_REGISTRY }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
 
-      - name: Build helm chart repo
-        shell: bash
-        run: make helmchart-repo VERSION=${VERSION} IMG=quay.io/${{ github.repository_owner }}/$(basename $GITHUB_REPOSITORY):${version} CHART_REPO_URL=https://${{ github.repository_owner }}.github.io/$(basename $GITHUB_REPOSITORY) HELM_REPO_DEST=./tmp/gh-pages
-      
-      - name: push helm repo to gh-pages
-        shell: bash
-        run: make helmchart-repo-push VERSION=${VERSION} IMG=quay.io/${{ github.repository_owner }}/$(basename $GITHUB_REPOSITORY):${version} CHART_REPO_URL=https://${{ github.repository_owner }}.github.io/$(basename $GITHUB_REPOSITORY) HELM_REPO_DEST=./tmp/gh-pages
+      - name: "Build Operator Image"
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./ci.Dockerfile
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: "${{ env.OPERATOR_IMAGE_REPOSITORY }}:latest,${{ env.OPERATOR_IMAGE_REPOSITORY }}:${{ env.OPERATOR_VERSION }}"
 
-  release-github:
-    name: GitHub Release
+      - name: Prepare Distribution Artifacts
+        shell: bash
+        run: |
+          # Create Distribution Directory
+          mkdir dist
+
+          # Move and Rename Manager Binary
+          mv bin/manager dist/${{ env.REPOSITORY_NAME }}-manager-${{ env.OPERATOR_VERSION }}-${{ steps.setup-build-step.outputs.platform_os }}-${{ steps.setup-build-step.outputs.platform_arch }}
+
+      - name: Upload Dist
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: dist
+
+  build-bundle:
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags')"
-    needs: ["build"]
+    name: build-bundle
+    needs: ["setup", "build-operator"]
+    env:
+      REPOSITORY_NAME: ${{ needs.setup.outputs.repository_name }}
+      OPERATOR_VERSION: ${{ needs.setup.outputs.operator_version }}
+      BUNDLE_VERSION: ${{ needs.setup.outputs.bundle_version }}
+      OPERATOR_IMAGE_REPOSITORY: "${{ needs.setup.outputs.operator_image_registry }}/${{ needs.setup.outputs.operator_image_repository_name }}"
+      OPERATOR_IMAGE_REGISTRY: ${{ needs.setup.outputs.operator_image_registry }}
+      BUNDLE_IMAGE_REPOSITORY: "${{ needs.setup.outputs.bundle_image_registry }}/${{ needs.setup.outputs.bundle_image_repository_name }}"
+      BUNDLE_IMAGE_REGISTRY: ${{ needs.setup.outputs.bundle_image_registry }}
     steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v1
+        with:
+          go-version: ^1.16
 
-      - name: set repo name
-        shell: bash
-        run: | 
-          echo "REPOSITORY_NAME=$(basename $GITHUB_REPOSITORY)" >> $GITHUB_ENV
-
-      - name: Checkout
+      - name: Check out code
         uses: actions/checkout@v2
 
-      - run: |
+      - name: Go Build Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ needs.setup.outputs.go_build }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+
+      - name: Go Mod Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ needs.setup.outputs.go_mod }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+
+      - name: Download Binaries
+        uses: actions/download-artifact@v2
+        with:
+          name: support-binaries
+          path: ${{ needs.setup.outputs.bin_dir }}
+
+      - name: Prepare Build Step
+        id: setup-build-step
+        run: |
+          # Setup Path
+          echo "${{ needs.setup.outputs.bin_dir }}" >> $GITHUB_PATH
+
+          # Make Binaries Executable
+          chmod +x ${{ needs.setup.outputs.bin_dir }}/*
+
+      - name: build bundle
+        shell: bash
+        run: make bundle IMG=${{ env.OPERATOR_IMAGE_REPOSITORY }}:${{ env.OPERATOR_VERSION }} VERSION=${{ env.BUNDLE_VERSION }} DEFAULT_CHANNEL=${{ env.DEFAULT_BUNDLE_CHANNEL }}
+
+      - name: Process Bundle for Disconnected Support
+        uses: redhat-cop/github-actions/disconnected-csv@master
+        with:
+          CSV_FILE: bundle/manifests/${{ env.REPOSITORY_NAME }}.clusterserviceversion.yaml
+          TAGS_TO_DIGESTS: ${OPERATOR_VERSION}
+
+      - name: "Copy bundle dockerfile"
+        shell: bash
+        run: sed  's/bundle\///g' bundle.Dockerfile > bundle/Dockerfile
+
+      - name: verify bundle
+        shell: bash
+        run: operator-sdk bundle validate ./bundle --select-optional name=operatorhub
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Bundle Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.BUNDLE_IMAGE_REGISTRY }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: "Build Bundle Image"
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+
+          file: ./bundle.Dockerfile
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: "${{ env.BUNDLE_IMAGE_REPOSITORY }}:latest,${{ env.BUNDLE_IMAGE_REPOSITORY }}:${{ env.BUNDLE_VERSION }}"
+
+      - name: Prepare Distribution Artifacts
+        shell: bash
+        run: |
+          # Create Distribution Directory
+          mkdir dist
+
+          # Prepare Bundle
+          cp -R bundle ${{ env.REPOSITORY_NAME }}-bundle-${{ env.OPERATOR_VERSION }}
+          tar -czvf ${{ env.REPOSITORY_NAME }}-bundle-${{ env.OPERATOR_VERSION }}.tar.gz ${{ env.REPOSITORY_NAME }}-bundle-${{ env.OPERATOR_VERSION }}
+          mv ${{ env.REPOSITORY_NAME }}-bundle-${{ env.OPERATOR_VERSION }}.tar.gz dist
+          rm -Rf ${{ env.REPOSITORY_NAME }}-bundle-${{ env.OPERATOR_VERSION }}
+
+      - name: Upload Dist
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: dist
+
+  package-helm:
+    runs-on: ubuntu-latest
+    name: package-helm
+    needs: ["setup"]
+    env:
+      REPOSITORY_NAME: ${{ needs.setup.outputs.repository_name }}
+      OPERATOR_VERSION: ${{ needs.setup.outputs.operator_version }}
+      HELM_RELEASE_VERSION: ${{ needs.setup.outputs.bundle_version }}
+      OPERATOR_IMAGE_REPOSITORY: "${{ needs.setup.outputs.operator_image_registry }}/${{ needs.setup.outputs.operator_image_repository_name }}"
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v1
+        with:
+          go-version: ^1.16
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Go Build Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ needs.setup.outputs.go_build }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+
+      - name: Go Mod Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ needs.setup.outputs.go_mod }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+
+      - name: Download Binaries
+        uses: actions/download-artifact@v2
+        with:
+          name: support-binaries
+          path: ${{ needs.setup.outputs.bin_dir }}
+
+      - name: Prepare Build Step
+        id: setup-build-step
+        run: |
+          # Setup Path
+          echo "${{ needs.setup.outputs.bin_dir }}" >> $GITHUB_PATH
+
+          # Make Binaries Executable
+          chmod +x ${{ needs.setup.outputs.bin_dir }}/*
+
+      - name: Build and Package Helm Chart
+        shell: bash
+        run: |
+          # Render Helm Chart
+          make helmchart VERSION=${{ env.HELM_RELEASE_VERSION }} IMG=${{ env.OPERATOR_IMAGE_REPOSITORY }}:${{ env.OPERATOR_VERSION }}
+
+          # Package Helm Chart
+          mkdir dist
+          helm package -d dist ./charts/${{ env.REPOSITORY_NAME }}
+
+      - name: Upload Dist
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: dist
+
+  github-release:
+    runs-on: ubuntu-latest
+    name: github-release
+    if: ${{ needs.setup.outputs.tag_event == 'true' }}
+    needs: ["setup", "build-operator", "build-bundle", "package-helm"]
+    env:
+      OPERATOR_VERSION: ${{ needs.setup.outputs.operator_version }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Fetch Code
+        run: |
           git fetch --prune --unshallow
-      - name: Get the version
-        id: get_version
-        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+
+      - name: Download Dist Directory
+        uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: dist
+
+      - name: Create Checksums for Release Artifacts
+        run: for i in `ls dist/`; do sha256sum dist/$i | awk '{ print $1 }' > dist/$i.sum256; done
 
       - name: Generate Changelog
         run: |
@@ -191,212 +453,152 @@ jobs:
           else
             REV_RANGE=${PREVIOUS_TAG}..${LATEST_TAG}
           fi
-          git log --pretty=format:"- %s %H (%aN)" --no-merges ${REV_RANGE} > ${VERSION}-CHANGELOG.txt
-          cat ${VERSION}-CHANGELOG.txt
+          git log --pretty=format:"- %s %H (%aN)" --no-merges ${REV_RANGE} > ${{ env.OPERATOR_VERSION }}-CHANGELOG.txt
+          cat ${{ env.OPERATOR_VERSION }}-CHANGELOG.txt
 
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
-          body_path: ${{ env.VERSION }}-CHANGELOG.txt
+          body_path: ${{ env.OPERATOR_VERSION }}-CHANGELOG.txt
           draft: false
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  
-  release-operatorhub:
-    name: Relase to OperatorHub via community-operators (We don't actually commit in this case)
+
+      - name: Upload release binaries
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: dist/*
+          tag: ${{ github.ref }}
+          overwrite: true
+          file_glob: true
+
+  helm-release:
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags')"
-    needs: ["build"]
+    name: helm-release
+    if: ${{ needs.setup.outputs.tag_event == 'true' }}
+    needs: ["setup", "build-operator", "build-bundle", "package-helm"]
+    env:
+      REPOSITORY_NAME: ${{ needs.setup.outputs.repository_name }}
+      HELM_RELEASE_VERSION: ${{ needs.setup.outputs.operator_version }}
     steps:
-
-      - name: set repo name
-        shell: bash
-        run: | 
-          echo "REPOSITORY_NAME=$(basename $GITHUB_REPOSITORY)" >> $GITHUB_ENV
-          echo "CONTEXT_PATH="
-
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v2
-        with:
-          go-version: ^1.16
-
-      # - uses: shivanshs9/setup-k8s-operator-sdk@v1
-      #   with:
-      #     version: "1.9.0" # The operator-sdk version to download (if necessary) and use.          
-
-      - name: Download operator sdk
-        shell: bash
-        env:
-          RELEASE_VERSION: v1.9.0
-        run: | 
-          curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk_linux_amd64
-          chmod +x operator-sdk_linux_amd64
-          mkdir ${HOME}/bin
-          mv operator-sdk_linux_amd64 ${HOME}/bin/operator-sdk
-          echo "${HOME}/bin" >> $GITHUB_PATH
-
-      - name: Get the version
-        id: get_version
-        run: |
-          export TAG=${GITHUB_REF/refs\/tags\//}
-          echo "VERSION=${TAG:1}" >> $GITHUB_ENV
-
-      - name: checkout community-operators-prod
+      - name: Checkout gh-pages Branch
         uses: actions/checkout@v2
         with:
-          repository: redhat-openshift-ecosystem/community-operators-prod
-          path: ./tmp/community-operators-prod
+          path: ${{ env.HELM_REPO_DIR }}
+          ref: gh-pages
 
-      - name: check whether it is first release
+      - name: Download Workspace Binaries
+        uses: actions/download-artifact@v2
+        with:
+          name: support-binaries
+          path: bin
+
+      - name: Download Dist Directory
+        uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: dist
+
+      - name: Prepare Build Step
+        id: setup-build-step
+        run: |
+          # Setup Path
+          echo "${{ needs.setup.outputs.bin_dir }}" >> $GITHUB_PATH
+
+          # Make Binaries Executable
+          chmod +x ${{ needs.setup.outputs.bin_dir }}/*
+
+      - name: Prepare Repository Update
+        run: |
+          cp dist/*.tgz ${{ env.HELM_REPO_DIR }}/${{ env.REPOSITORY_NAME }}/
+          helm repo index --url https://${{ github.repository_owner }}.github.io/${{ env.REPOSITORY_NAME }} ${{ env.HELM_REPO_DIR }}
+
+      - name: Configure Git
         shell: bash
         run: |
-          echo first_release=$([[ ! -d "./tmp/community-operators-prod/operators/$(basename $GITHUB_REPOSITORY)" ]] && echo 'true' || echo 'false') >> $GITHUB_ENV
-          echo $first_release
-      
-      - name: create and copy bundle to community operators
+          git config --global user.name "$GITHUB_ACTOR"
+          git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Publish Helm Repository
+        run: make helmchart-repo-push VERSION=${{ env.HELM_RELEASE_VERSION }} CHART_REPO_URL=https://${{ github.repository_owner }}.github.io/${{ env.REPOSITORY_NAME }} HELM_REPO_DEST=${{ env. HELM_REPO_DIR }}
+
+  operatorhub-release:
+    runs-on: ubuntu-latest
+    name: operatorhub-release
+    if: ${{ needs.setup.outputs.tag_event == 'true' }}
+    needs: ["setup", "github-release", "helm-release"]
+    env:
+      REPOSITORY_NAME: ${{ needs.setup.outputs.repository_name }}
+      OPERATOR_VERSION: ${{ needs.setup.outputs.operator_version }}
+      COMMUNITY_OPERATORS_ORGANIZATION_NAME: redhat-openshift-ecosystem
+      COMMUNITY_OPERATORS_REPOSITORY_NAME: community-operators-prod
+      BUNDLE_VERSION: ${{ needs.setup.outputs.bundle_version }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Checkout Community Operators
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ env.COMMUNITY_OPERATORS_ORGANIZATION_NAME }}/${{ env.COMMUNITY_OPERATORS_REPOSITORY_NAME }}
+          path: ./tmp/${{ env.COMMUNITY_OPERATORS_REPOSITORY_NAME }}
+
+      - name: Set Parameters
         shell: bash
-        run: | 
-          make bundle IMG=quay.io/${{ github.repository_owner }}/$(basename $GITHUB_REPOSITORY):v${VERSION} VERSION=${VERSION} DEFAULT_CHANNEL=alpha
-          sed  's/bundle\///g' bundle.Dockerfile > bundle/Dockerfile
-          sed -i '/replaces: '"$(basename $GITHUB_REPOSITORY)"'/d' ./bundle/manifests/$(basename $GITHUB_REPOSITORY).clusterserviceversion.yaml
-          mkdir -p ./tmp/community-operators-prod/operators/$(basename $GITHUB_REPOSITORY)/${VERSION}
-          /bin/cp -v -R ./bundle/* ./tmp/community-operators-prod/operators/$(basename $GITHUB_REPOSITORY)/${VERSION}
-          /bin/cp -v -R ./config/community-operators/* ./tmp/community-operators-prod/operators/$(basename $GITHUB_REPOSITORY)       
+        id: set-community-operators-parameters
+        run: |
+          if [ ! -d "./tmp/${{ env.COMMUNITY_OPERATORS_REPOSITORY_NAME }}/operators/${{ env.REPOSITORY_NAME }}" ]; then
+            export PR_REQUEST_BODY="$(cat config/community-operators/pr-first-release-body.txt)"
+          else
+            export PR_REQUEST_BODY="$(cat config/community-operators/pr-body.txt)"
+          fi
+          PR_REQUEST_BODY="${PR_REQUEST_BODY//'%'/'%25'}"
+          PR_REQUEST_BODY="${PR_REQUEST_BODY//$'\n'/'%0A'}"
+          PR_REQUEST_BODY="${PR_REQUEST_BODY//$'\r'/'%0D'}"
+          echo "::set-output name=pull-request-body::"$(echo $PR_REQUEST_BODY)""
 
-      - name: process bundle for disconnected support
-        uses: redhat-cop/github-actions/disconnected-csv@master
+      - name: Download Dist Directory
+        uses: actions/download-artifact@v2
         with:
-          CSV_FILE: "./tmp/community-operators-prod/operators/${{ env.REPOSITORY_NAME }}/${{ env.VERSION }}/manifests/${{ env.REPOSITORY_NAME }}.clusterserviceversion.yaml"
-          TAGS_TO_DIGESTS: ${OPERATOR_IMAGE_TAG}
+          name: dist
+          path: dist
+
+      - name: Untar Previously Created Bundle
+        shell: bash
+        run: |
+          # Create Bundle Directory
+          mkdir bundle
+
+          # Untar
+          ls dist/${{ env.REPOSITORY_NAME }}-bundle*.tar.gz | xargs -n1 tar -C bundle/ --strip-components=1 -xzvf
+
+      - name: Create and Copy Bundle to Community Operators
+        shell: bash
+        run: |
+          sed -i '/replaces: '"${{ env.REPOSITORY_NAME }}"'/d' ./bundle/manifests/${{ env.REPOSITORY_NAME }}.clusterserviceversion.yaml
+          mkdir -p ./tmp/${{ env.COMMUNITY_OPERATORS_REPOSITORY_NAME }}/operators/${{ env.REPOSITORY_NAME }}/${{ env.BUNDLE_VERSION }}
+          /bin/cp -v -R ./bundle/* ./tmp/${{ env.COMMUNITY_OPERATORS_REPOSITORY_NAME }}/operators/${{ env.REPOSITORY_NAME }}/${{ env.BUNDLE_VERSION }}
+          /bin/cp -v -R ./config/community-operators/*.yaml ./tmp/${{ env.COMMUNITY_OPERATORS_REPOSITORY_NAME }}/operators/${{ env.REPOSITORY_NAME }}
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
-        if: ${{ startsWith( env.first_release, 'true' ) }}
+        env:
+          PR_ACTOR: raffaele.spazzoli@gmail.com
         with:
-          path: ./tmp/community-operators-prod
-          commit-message: ${{ env.REPOSITORY_NAME }} release ${{ env.VERSION }}
-          committer: ${{ github.actor }} <raffaele.spazzoli@gmail.com>
-          author: ${{ github.actor }} <raffaele.spazzoli@gmail.com>
+          path: ./tmp/${{ env.COMMUNITY_OPERATORS_REPOSITORY_NAME }}
+          commit-message: ${{ env.REPOSITORY_NAME }} release ${{ env.BUNDLE_VERSION }}
+          committer: ${{ github.actor }} <${{ env.PR_ACTOR }}>
+          author: ${{ github.actor }} <${{ env.PR_ACTOR }}>
           signoff: true
-          branch: ${{ env.REPOSITORY_NAME }}-${{ env.VERSION }}
+          branch: ${{ env.REPOSITORY_NAME }}-${{ env.BUNDLE_VERSION }}
           delete-branch: true
-          push-to-fork: ${{ github.repository_owner }}/community-operators-prod
-          title: ${{ env.REPOSITORY_NAME }} initial commit
+          push-to-fork: ${{ github.repository_owner }}/${{ env.COMMUNITY_OPERATORS_REPOSITORY_NAME }}
+          title: ${{ env.REPOSITORY_NAME }} new version ${{ env.BUNDLE_VERSION }}
           body: |
-            ### New Submissions
-
-            * [x] Has you operator [nested directory structure](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#create-a-bundle)?
-            * [x] Have you selected the Project *Community Operator Submissions* in your PR on the right-hand menu bar?
-            * [x] Are you familiar with our [contribution guidelines](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md)?
-            * [x] Have you [packaged and deployed](https://github.com/operator-framework/community-operators/blob/master/docs/testing-operators.md) your Operator for Operator Framework?
-            * [x] Have you tested your Operator with all Custom Resource Definitions?
-            * [x] Have you tested your Operator in all supported [installation modes](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/building-your-csv.md#operator-metadata)?
-            * [x] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#sign-your-work)?
-
-            ### Updates to existing Operators
-
-            * [ ] Is your new CSV pointing to the previous version with the `replaces` property?
-            * [ ] Is your new CSV referenced in the [appropriate channel](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#bundle-format) defined in the `package.yaml` ?
-            * [ ] Have you tested an update to your Operator when deployed via OLM?
-            * [ ] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#sign-your-work)?
-
-            ### Your submission should not
-
-            * [x] Modify more than one operator
-            * [x] Modify an Operator you don't own
-            * [x] Rename an operator - please remove and add with a different name instead
-            * [x] Submit operators to both `upstream-community-operators` and `community-operators` at once
-            * [x] Modify any files outside the above mentioned folders
-            * [x] Contain more than one commit. **Please squash your commits.**
-
-            ### Operator Description must contain (in order)
-
-            1. [x] Description about the managed Application and where to find more information
-            2. [x] Features and capabilities of your Operator and how to use it
-            3. [x] Any manual steps about potential pre-requisites for using your Operator
-
-            ### Operator Metadata should contain
-
-            * [x] Human readable name and 1-liner description about your Operator
-            * [x] Valid [category name](https://github.com/operator-framework/community-operators/blob/master/docs/required-fields.md#categories)<sup>1</sup>
-            * [x] One of the pre-defined [capability levels](https://github.com/operator-framework/operator-courier/blob/4d1a25d2c8d52f7de6297ec18d8afd6521236aa2/operatorcourier/validate.py#L556)<sup>2</sup>
-            * [x] Links to the maintainer, source code and documentation
-            * [x] Example templates for all Custom Resource Definitions intended to be used
-            * [x] A quadratic logo
-
-            Remember that you can preview your CSV [here](https://operatorhub.io/preview).
-
-            --
-
-            <sup>1</sup> If you feel your Operator does not fit any of the pre-defined categories, file a PR against this repo and explain your need
-
-            <sup>2</sup> For more information see [here](https://github.com/operator-framework/operator-sdk/blob/master/doc/images/operator-capability-level.svg)
+            ${{ steps.set-community-operators-parameters.outputs.pull-request-body }}
           token: ${{ secrets.COMMUNITY_OPERATOR_PAT }}
-
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
-        if: ${{ ! startsWith( env.first_release, 'true' ) }} 
-        with:
-          path: ./tmp/community-operators-prod
-          commit-message: ${{ env.REPOSITORY_NAME }} release ${{ env.VERSION }}
-          committer: ${{ github.actor }} <raffaele.spazzoli@gmail.com>
-          author: ${{ github.actor }} <raffaele.spazzoli@gmail.com>
-          signoff: true
-          branch: ${{ env.REPOSITORY_NAME }}-${{ env.VERSION }}
-          delete-branch: true
-          push-to-fork: ${{ github.repository_owner }}/community-operators-prod
-          title: ${{ env.REPOSITORY_NAME }} new version ${{ env.VERSION }}
-          body: |
-            ### New Submissions
-
-            * [ ] Has you operator [nested directory structure](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#create-a-bundle)?
-            * [ ] Have you selected the Project *Community Operator Submissions* in your PR on the right-hand menu bar?
-            * [ ] Are you familiar with our [contribution guidelines](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md)?
-            * [ ] Have you [packaged and deployed](https://github.com/operator-framework/community-operators/blob/master/docs/testing-operators.md) your Operator for Operator Framework?
-            * [ ] Have you tested your Operator with all Custom Resource Definitions?
-            * [ ] Have you tested your Operator in all supported [installation modes](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/building-your-csv.md#operator-metadata)?
-            * [ ] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#sign-your-work)?
-
-            ### Updates to existing Operators
-
-            * [x] Is your new CSV pointing to the previous version with the `replaces` property?
-            * [x] Is your new CSV referenced in the [appropriate channel](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#bundle-format) defined in the `package.yaml` ?
-            * [ ] Have you tested an update to your Operator when deployed via OLM?
-            * [x] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#sign-your-work)?
-
-            ### Your submission should not
-
-            * [x] Modify more than one operator
-            * [x] Modify an Operator you don't own
-            * [x] Rename an operator - please remove and add with a different name instead
-            * [x] Submit operators to both `upstream-community-operators` and `community-operators` at once
-            * [x] Modify any files outside the above mentioned folders
-            * [x] Contain more than one commit. **Please squash your commits.**
-
-            ### Operator Description must contain (in order)
-
-            1. [x] Description about the managed Application and where to find more information
-            2. [x] Features and capabilities of your Operator and how to use it
-            3. [x] Any manual steps about potential pre-requisites for using your Operator
-
-            ### Operator Metadata should contain
-
-            * [x] Human readable name and 1-liner description about your Operator
-            * [x] Valid [category name](https://github.com/operator-framework/community-operators/blob/master/docs/required-fields.md#categories)<sup>1</sup>
-            * [x] One of the pre-defined [capability levels](https://github.com/operator-framework/operator-courier/blob/4d1a25d2c8d52f7de6297ec18d8afd6521236aa2/operatorcourier/validate.py#L556)<sup>2</sup>
-            * [x] Links to the maintainer, source code and documentation
-            * [x] Example templates for all Custom Resource Definitions intended to be used
-            * [x] A quadratic logo
-
-            Remember that you can preview your CSV [here](https://operatorhub.io/preview).
-
-            --
-
-            <sup>1</sup> If you feel your Operator does not fit any of the pre-defined categories, file a PR against this repo and explain your need
-
-            <sup>2</sup> For more information see [here](https://github.com/operator-framework/operator-sdk/blob/master/doc/images/operator-capability-level.svg)
-          token:  ${{ secrets.COMMUNITY_OPERATOR_PAT }}

--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -1,0 +1,7 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+WORKDIR /
+COPY config/templates /templates
+COPY bin/manager .
+USER 65532:65532
+
+ENTRYPOINT ["/manager"]

--- a/config/community-operators/pr-body.txt
+++ b/config/community-operators/pr-body.txt
@@ -1,0 +1,35 @@
+### New Submissions
+* [ ] Has you operator [nested directory structure](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#create-a-bundle)?
+* [ ] Have you selected the Project *Community Operator Submissions* in your PR on the right-hand menu bar?
+* [ ] Are you familiar with our [contribution guidelines](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md)?
+* [ ] Have you [packaged and deployed](https://github.com/operator-framework/community-operators/blob/master/docs/testing-operators.md) your Operator for Operator Framework?
+* [ ] Have you tested your Operator with all Custom Resource Definitions?
+* [ ] Have you tested your Operator in all supported [installation modes](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/building-your-csv.md#operator-metadata)?
+* [ ] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#sign-your-work)?
+### Updates to existing Operators
+* [x] Is your new CSV pointing to the previous version with the `replaces` property?
+* [x] Is your new CSV referenced in the [appropriate channel](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#bundle-format) defined in the `package.yaml` ?
+* [ ] Have you tested an update to your Operator when deployed via OLM?
+* [x] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#sign-your-work)?
+### Your submission should not
+* [x] Modify more than one operator
+* [x] Modify an Operator you don't own
+* [x] Rename an operator - please remove and add with a different name instead
+* [x] Submit operators to both `upstream-community-operators` and `community-operators` at once
+* [x] Modify any files outside the above mentioned folders
+* [x] Contain more than one commit. **Please squash your commits.**
+### Operator Description must contain (in order)
+1. [x] Description about the managed Application and where to find more information
+2. [x] Features and capabilities of your Operator and how to use it
+3. [x] Any manual steps about potential pre-requisites for using your Operator
+### Operator Metadata should contain
+* [x] Human readable name and 1-liner description about your Operator
+* [x] Valid [category name](https://github.com/operator-framework/community-operators/blob/master/docs/required-fields.md#categories)<sup>1</sup>
+* [x] One of the pre-defined [capability levels](https://github.com/operator-framework/operator-courier/blob/4d1a25d2c8d52f7de6297ec18d8afd6521236aa2/operatorcourier/validate.py#L556)<sup>2</sup>
+* [x] Links to the maintainer, source code and documentation
+* [x] Example templates for all Custom Resource Definitions intended to be used
+* [x] A quadratic logo
+Remember that you can preview your CSV [here](https://operatorhub.io/preview).
+--
+<sup>1</sup> If you feel your Operator does not fit any of the pre-defined categories, file a PR against this repo and explain your need
+<sup>2</sup> For more information see [here](https://github.com/operator-framework/operator-sdk/blob/master/doc/images/operator-capability-level.svg)

--- a/config/community-operators/pr-first-release-body.txt
+++ b/config/community-operators/pr-first-release-body.txt
@@ -1,0 +1,35 @@
+### New Submissions
+* [x] Has you operator [nested directory structure](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#create-a-bundle)?
+* [x] Have you selected the Project *Community Operator Submissions* in your PR on the right-hand menu bar?
+* [x] Are you familiar with our [contribution guidelines](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md)?
+* [x] Have you [packaged and deployed](https://github.com/operator-framework/community-operators/blob/master/docs/testing-operators.md) your Operator for Operator Framework?
+* [x] Have you tested your Operator with all Custom Resource Definitions?
+* [x] Have you tested your Operator in all supported [installation modes](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/building-your-csv.md#operator-metadata)?
+* [x] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#sign-your-work)?
+### Updates to existing Operators
+* [ ] Is your new CSV pointing to the previous version with the `replaces` property?
+* [ ] Is your new CSV referenced in the [appropriate channel](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#bundle-format) defined in the `package.yaml` ?
+* [ ] Have you tested an update to your Operator when deployed via OLM?
+* [ ] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing.md#sign-your-work)?
+### Your submission should not
+* [x] Modify more than one operator
+* [x] Modify an Operator you don't own
+* [x] Rename an operator - please remove and add with a different name instead
+* [x] Submit operators to both `upstream-community-operators` and `community-operators` at once
+* [x] Modify any files outside the above mentioned folders
+* [x] Contain more than one commit. **Please squash your commits.**
+### Operator Description must contain (in order)
+1. [x] Description about the managed Application and where to find more information
+2. [x] Features and capabilities of your Operator and how to use it
+3. [x] Any manual steps about potential pre-requisites for using your Operator
+### Operator Metadata should contain
+* [x] Human readable name and 1-liner description about your Operator
+* [x] Valid [category name](https://github.com/operator-framework/community-operators/blob/master/docs/required-fields.md#categories)<sup>1</sup>
+* [x] One of the pre-defined [capability levels](https://github.com/operator-framework/operator-courier/blob/4d1a25d2c8d52f7de6297ec18d8afd6521236aa2/operatorcourier/validate.py#L556)<sup>2</sup>
+* [x] Links to the maintainer, source code and documentation
+* [x] Example templates for all Custom Resource Definitions intended to be used
+* [x] A quadratic logo
+Remember that you can preview your CSV [here](https://operatorhub.io/preview).
+--
+<sup>1</sup> If you feel your Operator does not fit any of the pre-defined categories, file a PR against this repo and explain your need
+<sup>2</sup> For more information see [here](https://github.com/operator-framework/operator-sdk/blob/master/doc/images/operator-capability-level.svg)


### PR DESCRIPTION
Reference implementation of a refactor of the Operators pipelines

## Key themes

* Golang caching
* Parallel + Matrix builds
* Reusing artifacts in jobs
* Ability to specify operator and bundle registry desgination
* Omitting the manager build as part of the image build
* Reduction of redundant code/tass
* Publishing release artifacts

## Required actions

Several changes were introduced as part of this refactoring effort which would need to be replicated across the rest of the operators:

1. Secret name changes
    1. `QUAY_USERNAME` -> `REGISTRY_USERNAME`
    2. `QUAY_PASSWORD` -> `REGISTRY_PASSWORD`
2. CI Dockerfile
A new Dockerfile specifically for CI called `ci.Dockerfile` was introduced that expects the `manager` binary to be prebuilt in the `bin` folder instead of executing a build of the `manager` artifact
3. Pull request body content
The content for the pull requests to the Community Operators repository was externalized to the `config/community-operators` directory reduce the content within the workflows.
4. Items specific to this repository
This repository also includes _templates_ that are injected to the operator image. When replicating the content of this effort throughout the rest of the operators, this logic must not be implemented

