### PR TITLE
Update kube-rbac-proxy to v4.9

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:6d57bfd91fac9b68eb72d27226bc297472ceb136c996628b845ecc54a48b31cb
+        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:902233b05914e8fc9ac3ed5816827f4310c9a5380f516078244147b7de2d20e1
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
This is required for ARM, for which 4.9 is the initial version.
